### PR TITLE
Revert to initial stoi indexing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     timeout-minutes: 10
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.8
 
     - name: Install python dependencies
       run: |


### PR DESCRIPTION
I'm reverting to the initial pystoi indexing which seems right, and passes the unit tests with Octave. 

@philgzl, can you double-check that it looks alright, please ? 