### PR TITLE
Fixing EPS application when applying sqrt 

### DIFF
--- a/torch_stoi/stoi.py
+++ b/torch_stoi/stoi.py
@@ -156,8 +156,8 @@ class NegSTOILoss(nn.Module):
         #         mask = mask[~not_enough]
 
         # Apply OB matrix to the spectrograms as in Eq. (1)
-        x_tob = torch.matmul(self.OBM, x_spec.abs().pow(2) + EPS).sqrt()
-        y_tob = torch.matmul(self.OBM, y_spec.abs().pow(2) + EPS).sqrt()
+        x_tob = (torch.matmul(self.OBM, x_spec.abs().pow(2)) + EPS).sqrt()
+        y_tob = (torch.matmul(self.OBM, y_spec.abs().pow(2)) + EPS).sqrt()
 
         # Perform N-frame segmentation --> (batch, 15, N, n_chunks)
         x_seg = unfold(x_tob.unsqueeze(2),


### PR DESCRIPTION
## Problem

- When using the pytorch_stoi loss in some training sessions some NaN values are were appearing
- One of the possible cause would be related to the sqrt operation since the gradient will lead to a singularity
- An EPS is applied in the current implementation but the order of the operations can allow for exploding gradients

# Solution

- Sum EPS just before applying sqrt